### PR TITLE
Further messing arround - primarily moving Timber's cache methods from Loader to new Cache class

### DIFF
--- a/lib/Cache.php
+++ b/lib/Cache.php
@@ -99,7 +99,7 @@ class Cache
 	 * @param string $cache_mode
 	 * @return bool
 	 */
-	public function get_cache( $key, $group = self::CACHEGROUP, $cache_mode = self::CACHE_USE_DEFAULT ) {
+	public function fetch( $key, $group = self::CACHEGROUP, $cache_mode = self::CACHE_USE_DEFAULT ) {
 		$value = false;
 
 		$trans_key = substr($group.'_'.$key, 0, self::TRANS_KEY_LEN);
@@ -137,7 +137,7 @@ class Cache
 	 * @param string $cache_mode
 	 * @return string|boolean
 	 */
-	public function set_cache( $key, $value, $group = self::CACHEGROUP, $expires = 0, $cache_mode = self::CACHE_USE_DEFAULT ) {
+	public function save( $key, $value, $group = self::CACHEGROUP, $expires = 0, $cache_mode = self::CACHE_USE_DEFAULT ) {
 		if ( (int) $expires < 1 ) {
 			$expires = 0;
 		}

--- a/lib/Cache.php
+++ b/lib/Cache.php
@@ -4,7 +4,7 @@ namespace Timber;
 
 use Timber\Cache\Cleaner;
 
-class Loader 
+class Cache 
 {
 	const CACHEGROUP = 'timberloader';
 

--- a/lib/Cache.php
+++ b/lib/Cache.php
@@ -48,43 +48,6 @@ class Cache
 		Cleaner::delete_transients();
 	}
 
-	/**
-	 * @param string $name
-	 * @return bool
-	 * @deprecated 1.3.5 No longer used internally
-	 * @todo remove in 2.x
-	 * @codeCoverageIgnore
-	 */
-	protected function template_exists( $name ) {
-		return $this->twig->getLoader()->exists($name);
-	}
-
-
-	/**
-	 * @return \Twig_LoaderInterface
-	 * @deprecated No longer relevant due to Twig_Environment::getLoader().
-	 * @todo remove
-	 */
-	public function get_loader() {
-// TODO: Remove.
-		// This returns a proxy filesystem loader to preserve backward compatibility, by letting users add (but not remove internal) paths.
-		if ($this->twig->getLoader() instanceof ChainLoader) {
-			return $this->twig->getLoader()->getTemporaryLoader();
-		}
-		// Just return loader...
-		return $this->twig->getLoader();
-	}
-
-
-	/**
-	 * @return \Twig_Environment
-	 * @deprecated Since class now extends Twig_Environment.
-	 * @todo remove
-	 */
-	public function get_twig() {
-		return $this->twigEnvironment;
-	}
-
 	public function clear_cache_timber( $cache_mode = self::CACHE_USE_DEFAULT ) {
 		$cache_mode = $this->_get_cache_mode($cache_mode);
 		switch ($cache_mode) {
@@ -125,39 +88,6 @@ class Cache
 			}
 			return true;
 		}
-	}
-
-	public function clear_cache_twig() {
-		if ( method_exists($this, 'clearCacheFiles') ) {
-			$this->clearCacheFiles();
-		}
-		$cache = $this->twigEnvironment->getCache();
-		if ( $cache ) {
-			self::rrmdir($this->twigEnvironment->getCache());
-			return true;
-		}
-		return false;
-	}
-
-	/**
-	 * @param string|false $dirPath
-	 */
-	public static function rrmdir( $dirPath ) {
-		if ( !is_dir($dirPath) ) {
-			throw new \InvalidArgumentException("$dirPath must be a directory");
-		}
-		if ( substr($dirPath, strlen($dirPath) - 1, 1) != '/' ) {
-			$dirPath .= '/';
-		}
-		$files = glob($dirPath.'*', GLOB_MARK);
-		foreach ( $files as $file ) {
-			if ( is_dir($file) ) {
-				self::rrmdir($file);
-			} else {
-				unlink($file);
-			}
-		}
-		rmdir($dirPath);
 	}
 
 	/**

--- a/lib/Cache.php
+++ b/lib/Cache.php
@@ -25,23 +25,13 @@ class Cache
 
 	protected $cache_mode = self::CACHE_TRANSIENT;
 
-	private $twigEnvironment;
-	
 	/**
 	 *
-	 * @param \Twig_Environment $twig
 	 */
-	public function __construct(\Twig_Environment $twig = null)
+	public function __construct()
 	{	
-		if ($twig !== null) {
-			$this->twigEnvironment = $twig;
-		}
-		
 		$this->cache_mode = apply_filters('timber_cache_mode', $this->cache_mode);
 		$this->cache_mode = apply_filters('timber/cache/mode', $this->cache_mode);
-
-// TODO: Enable this again, somewhere else...
-//		$twig->addExtension($this->_get_cache_extension());
 	}
 
 	public function delete_cache() {

--- a/lib/Cache.php
+++ b/lib/Cache.php
@@ -1,0 +1,269 @@
+<?php
+
+namespace Timber;
+
+use Timber\Cache\Cleaner;
+
+class Loader 
+{
+	const CACHEGROUP = 'timberloader';
+
+	const TRANS_KEY_LEN = 50;
+
+	const CACHE_NONE = 'none';
+	const CACHE_OBJECT = 'cache';
+	const CACHE_TRANSIENT = 'transient';
+	const CACHE_SITE_TRANSIENT = 'site-transient';
+	const CACHE_USE_DEFAULT = 'default';
+
+	public static $cache_modes = array(
+		self::CACHE_NONE,
+		self::CACHE_OBJECT,
+		self::CACHE_TRANSIENT,
+		self::CACHE_SITE_TRANSIENT
+	);
+
+	protected $cache_mode = self::CACHE_TRANSIENT;
+
+	private $twigEnvironment;
+	
+	/**
+	 *
+	 * @param \Twig_Environment $twig
+	 */
+	public function __construct(\Twig_Environment $twig = null)
+	{	
+		if ($twig !== null) {
+			$this->twigEnvironment = $twig;
+		}
+		
+		$this->cache_mode = apply_filters('timber_cache_mode', $this->cache_mode);
+		$this->cache_mode = apply_filters('timber/cache/mode', $this->cache_mode);
+
+// TODO: Enable this again, somewhere else...
+//		$twig->addExtension($this->_get_cache_extension());
+	}
+
+	public function delete_cache() {
+		Cleaner::delete_transients();
+	}
+
+	/**
+	 * @param string $name
+	 * @return bool
+	 * @deprecated 1.3.5 No longer used internally
+	 * @todo remove in 2.x
+	 * @codeCoverageIgnore
+	 */
+	protected function template_exists( $name ) {
+		return $this->twig->getLoader()->exists($name);
+	}
+
+
+	/**
+	 * @return \Twig_LoaderInterface
+	 * @deprecated No longer relevant due to Twig_Environment::getLoader().
+	 * @todo remove
+	 */
+	public function get_loader() {
+// TODO: Remove.
+		// This returns a proxy filesystem loader to preserve backward compatibility, by letting users add (but not remove internal) paths.
+		if ($this->twig->getLoader() instanceof ChainLoader) {
+			return $this->twig->getLoader()->getTemporaryLoader();
+		}
+		// Just return loader...
+		return $this->twig->getLoader();
+	}
+
+
+	/**
+	 * @return \Twig_Environment
+	 * @deprecated Since class now extends Twig_Environment.
+	 * @todo remove
+	 */
+	public function get_twig() {
+		return $this->twigEnvironment;
+	}
+
+	public function clear_cache_timber( $cache_mode = self::CACHE_USE_DEFAULT ) {
+		$cache_mode = $this->_get_cache_mode($cache_mode);
+		switch ($cache_mode) {
+				
+			case self::CACHE_TRANSIENT:
+			case self::CACHE_SITE_TRANSIENT:
+				return self::clear_cache_timber_database();
+			
+			case self::CACHE_OBJECT:
+				$object_cache = isset($GLOBALS['wp_object_cache']) && is_object($GLOBALS['wp_object_cache']);
+				if ($object_cache) {
+					return self::clear_cache_timber_object();
+				}
+				break;
+			
+			default:
+// TODO:
+		}
+
+		return false;
+	}
+
+	protected static function clear_cache_timber_database() {
+		global $wpdb;
+		$query = $wpdb->prepare("DELETE FROM $wpdb->options WHERE option_name LIKE '%s'", '_transient_timberloader_%');
+		return $wpdb->query($query);
+	}
+
+	protected static function clear_cache_timber_object() {
+		global $wp_object_cache;
+		if ( isset($wp_object_cache->cache[self::CACHEGROUP]) ) {
+			$items = $wp_object_cache->cache[self::CACHEGROUP];
+			foreach ( $items as $key => $value ) {
+				if ( is_multisite() ) {
+					$key = preg_replace('/^(.*?):/', '', $key);
+				}
+				wp_cache_delete($key, self::CACHEGROUP);
+			}
+			return true;
+		}
+	}
+
+	public function clear_cache_twig() {
+		if ( method_exists($this, 'clearCacheFiles') ) {
+			$this->clearCacheFiles();
+		}
+		$cache = $this->twigEnvironment->getCache();
+		if ( $cache ) {
+			self::rrmdir($this->twigEnvironment->getCache());
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * @param string|false $dirPath
+	 */
+	public static function rrmdir( $dirPath ) {
+		if ( !is_dir($dirPath) ) {
+			throw new \InvalidArgumentException("$dirPath must be a directory");
+		}
+		if ( substr($dirPath, strlen($dirPath) - 1, 1) != '/' ) {
+			$dirPath .= '/';
+		}
+		$files = glob($dirPath.'*', GLOB_MARK);
+		foreach ( $files as $file ) {
+			if ( is_dir($file) ) {
+				self::rrmdir($file);
+			} else {
+				unlink($file);
+			}
+		}
+		rmdir($dirPath);
+	}
+
+	/**
+	 * @return \Asm89\Twig\CacheExtension\Extension
+	 */
+	public static function createCacheExtension() {
+
+		$key_generator   = new \Timber\Cache\KeyGenerator();
+		$cache_provider  = new \Timber\Cache\WPObjectCacheAdapter(new self());
+		$cache_strategy  = new \Asm89\Twig\CacheExtension\CacheStrategy\GenerationalCacheStrategy($cache_provider, $key_generator);
+		$cache_extension = new \Asm89\Twig\CacheExtension\Extension($cache_strategy);
+
+		return $cache_extension;
+	}
+
+	/**
+	 * @param string $key
+	 * @param string $group
+	 * @param string $cache_mode
+	 * @return bool
+	 */
+	public function get_cache( $key, $group = self::CACHEGROUP, $cache_mode = self::CACHE_USE_DEFAULT ) {
+		$value = false;
+
+		$trans_key = substr($group.'_'.$key, 0, self::TRANS_KEY_LEN);
+		
+		$cache_mode = $this->_get_cache_mode($cache_mode);
+		switch ($cache_mode) {
+				
+			case self::CACHE_TRANSIENT:
+				$value = get_transient($trans_key);
+				break;
+				
+			case self::CACHE_SITE_TRANSIENT:
+				$value = get_site_transient($trans_key);
+				break;
+
+			case self::CACHE_OBJECT:
+				$object_cache = isset($GLOBALS['wp_object_cache']) && is_object($GLOBALS['wp_object_cache']);
+				if ($object_cache) {
+					$value = wp_cache_get($key, $group);
+				}
+				break;
+				
+			default:
+// TODO:
+		}
+
+		return $value;
+	}
+
+	/**
+	 * @param string $key
+	 * @param string|boolean $value
+	 * @param string $group
+	 * @param integer $expires
+	 * @param string $cache_mode
+	 * @return string|boolean
+	 */
+	public function set_cache( $key, $value, $group = self::CACHEGROUP, $expires = 0, $cache_mode = self::CACHE_USE_DEFAULT ) {
+		if ( (int) $expires < 1 ) {
+			$expires = 0;
+		}
+
+		$trans_key = substr($group.'_'.$key, 0, self::TRANS_KEY_LEN);
+
+		$cache_mode = self::_get_cache_mode($cache_mode);
+		switch ($cache_mode) {
+		
+			case self::CACHE_TRANSIENT:
+				set_transient($trans_key, $value, $expires);
+				break;
+		
+			case self::CACHE_SITE_TRANSIENT:
+				set_site_transient($trans_key, $value, $expires);
+				break;
+		
+			case self::CACHE_OBJECT:
+				$object_cache = isset($GLOBALS['wp_object_cache']) && is_object($GLOBALS['wp_object_cache']);
+				if ($object_cache) {
+					wp_cache_set($key, $value, $group, $expires);
+				}
+				break;
+
+			default:
+// TODO: 
+		}
+
+		return $value;
+	}
+
+	/**
+	 * @param string $cache_mode
+	 * @return string
+	 */
+	private function _get_cache_mode( $cache_mode ) {
+		if ( empty($cache_mode) || self::CACHE_USE_DEFAULT === $cache_mode ) {
+			$cache_mode = $this->cache_mode;
+		}
+
+		// Fallback if self::$cache_mode did not get a valid value
+		if ( !in_array($cache_mode, self::$cache_modes) ) {
+			$cache_mode = self::CACHE_OBJECT;
+		}
+
+		return $cache_mode;
+	}
+
+}

--- a/lib/Cache/WPObjectCacheAdapter.php
+++ b/lib/Cache/WPObjectCacheAdapter.php
@@ -18,11 +18,11 @@ class WPObjectCacheAdapter implements CacheProviderInterface {
 	}
 
 	public function fetch( $key ) {
-		return $this->timberCache->get_cache($key, $this->cache_group, Cache::CACHE_USE_DEFAULT);
+		return $this->timberCache->fetch($key, $this->cache_group, Cache::CACHE_USE_DEFAULT);
 	}
 
 	public function save( $key, $value, $expire = 0 ) {
-		return $this->timberCache->set_cache($key, $value, $this->cache_group, $expire, Cache::CACHE_USE_DEFAULT);
+		return $this->timberCache->save($key, $value, $this->cache_group, $expire, Cache::CACHE_USE_DEFAULT);
 	}
 
 }

--- a/lib/Cache/WPObjectCacheAdapter.php
+++ b/lib/Cache/WPObjectCacheAdapter.php
@@ -1,28 +1,28 @@
 <?php namespace Timber\Cache;
 
 use Asm89\Twig\CacheExtension\CacheProviderInterface;
-use Timber\Loader;
+use Timber\Cache;
 
 class WPObjectCacheAdapter implements CacheProviderInterface {
 
 	private $cache_group;
 
 	/**
-	 * @var TimberLoader
+	 * @var TimberCache
 	 */
-	private $timberloader;
+	private $timberCache;
 
-	public function __construct( Loader $timberloader, $cache_group = 'timber' ) {
+	public function __construct( Cache $timberCache, $cache_group = 'timber' ) {
 		$this->cache_group = $cache_group;
-		$this->timberloader = $timberloader;
+		$this->timberCache = $timberCache;
 	}
 
 	public function fetch( $key ) {
-		return $this->timberloader->get_cache($key, $this->cache_group, Loader::CACHE_USE_DEFAULT);
+		return $this->timberCache->get_cache($key, $this->cache_group, Cache::CACHE_USE_DEFAULT);
 	}
 
 	public function save( $key, $value, $expire = 0 ) {
-		return $this->timberloader->set_cache($key, $value, $this->cache_group, $expire, Loader::CACHE_USE_DEFAULT);
+		return $this->timberCache->set_cache($key, $value, $this->cache_group, $expire, Cache::CACHE_USE_DEFAULT);
 	}
 
 }

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -5,7 +5,6 @@ namespace Timber;
 use Timber\Cache\Cleaner;
 
 class Loader
-	extends Cache
 {
 	const CACHEGROUP = Cache::CACHEGROUP;
 
@@ -25,6 +24,7 @@ class Loader
 	);
 
 	private $twigEnvironment;
+	private $cacheInstance;
 	
 	/**
 	 *
@@ -36,7 +36,7 @@ class Loader
 			$this->twigEnvironment = $twig;
 		}
 		
-		parent::__construct();
+		$this->cacheInstance = new Cache();
 	}
 
 	/**
@@ -77,7 +77,7 @@ class Loader
 	}
 
 	public function clear_cache_timber( $cache_mode = self::CACHE_USE_DEFAULT ) {
-		return parent::clear_cache_timber( $cache_mode);
+		return $this->cacheInstance->clear_cache_timber( $cache_mode);
 	}
 
 	public function clear_cache_twig() {
@@ -117,7 +117,7 @@ class Loader
 	 * @return \Asm89\Twig\CacheExtension\Extension
 	 */
 	public static function createCacheExtension() {
-		return parent::createCacheExtension();
+		return Cache::createCacheExtension();
 	}
 
 	/**
@@ -127,7 +127,7 @@ class Loader
 	 * @return bool
 	 */
 	public function get_cache( $key, $group = self::CACHEGROUP, $cache_mode = self::CACHE_USE_DEFAULT ) {
-		return parent::fetch( $key, $group, $cache_mode);
+		return $this->cacheInstance->fetch( $key, $group, $cache_mode);
 	}
 
 	/**
@@ -139,6 +139,6 @@ class Loader
 	 * @return string|boolean
 	 */
 	public function set_cache( $key, $value, $group = self::CACHEGROUP, $expires = 0, $cache_mode = self::CACHE_USE_DEFAULT ) {
-		return parent::save( $key, $value, $group, $expires, $cache_mode);
+		return $this->cacheInstance->save( $key, $value, $group, $expires, $cache_mode);
 	}
 }

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -38,7 +38,7 @@ class Loader
 			$this->twigEnvironment = $twig;
 		}
 		
-
+		parent::__construct();
 		
 // TODO: Enable this again, somewhere else...
 //		$twig->addExtension($this->_get_cache_extension());

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -80,6 +80,7 @@ class Loader
 	}
 
 	public function clear_cache_timber( $cache_mode = self::CACHE_USE_DEFAULT ) {
+		return parent::clear_cache_timber( $cache_mode);
 	}
 
 	public function clear_cache_twig() {
@@ -119,6 +120,7 @@ class Loader
 	 * @return \Asm89\Twig\CacheExtension\Extension
 	 */
 	public static function createCacheExtension() {
+		return parent::createCacheExtension();
 	}
 
 	/**

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -5,6 +5,7 @@ namespace Timber;
 use Timber\Cache\Cleaner;
 
 class Loader 
+	extends Cache
 {
 	const CACHEGROUP = 'timberloader';
 

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -4,7 +4,7 @@ namespace Timber;
 
 use Timber\Cache\Cleaner;
 
-class Loader 
+class Loader
 	extends Cache
 {
 	const CACHEGROUP = Cache::CACHEGROUP;
@@ -37,9 +37,6 @@ class Loader
 		}
 		
 		parent::__construct();
-		
-// TODO: Enable this again, somewhere else...
-//		$twig->addExtension($this->_get_cache_extension());
 	}
 
 	/**

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -130,6 +130,7 @@ class Loader
 	 * @return bool
 	 */
 	public function get_cache( $key, $group = self::CACHEGROUP, $cache_mode = self::CACHE_USE_DEFAULT ) {
+		return parent::fetch( $key, $group, $cache_mode);
 	}
 
 	/**
@@ -141,6 +142,6 @@ class Loader
 	 * @return string|boolean
 	 */
 	public function set_cache( $key, $value, $group = self::CACHEGROUP, $expires = 0, $cache_mode = self::CACHE_USE_DEFAULT ) {
+		return parent::save( $key, $value, $group, $expires, $cache_mode);
 	}
-
 }

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -24,8 +24,6 @@ class Loader
 		self::CACHE_SITE_TRANSIENT
 	);
 
-	protected $cache_mode = self::CACHE_TRANSIENT;
-
 	private $twigEnvironment;
 	
 	/**
@@ -43,7 +41,6 @@ class Loader
 // TODO: Enable this again, somewhere else...
 //		$twig->addExtension($this->_get_cache_extension());
 	}
-
 
 	/**
 	 * @param string $name

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -38,16 +38,12 @@ class Loader
 			$this->twigEnvironment = $twig;
 		}
 		
-		$this->cache_mode = apply_filters('timber_cache_mode', $this->cache_mode);
-		$this->cache_mode = apply_filters('timber/cache/mode', $this->cache_mode);
 
+		
 // TODO: Enable this again, somewhere else...
 //		$twig->addExtension($this->_get_cache_extension());
 	}
 
-	public function delete_cache() {
-		Cleaner::delete_transients();
-	}
 
 	/**
 	 * @param string $name
@@ -87,45 +83,6 @@ class Loader
 	}
 
 	public function clear_cache_timber( $cache_mode = self::CACHE_USE_DEFAULT ) {
-		$cache_mode = $this->_get_cache_mode($cache_mode);
-		switch ($cache_mode) {
-				
-			case self::CACHE_TRANSIENT:
-			case self::CACHE_SITE_TRANSIENT:
-				return self::clear_cache_timber_database();
-			
-			case self::CACHE_OBJECT:
-				$object_cache = isset($GLOBALS['wp_object_cache']) && is_object($GLOBALS['wp_object_cache']);
-				if ($object_cache) {
-					return self::clear_cache_timber_object();
-				}
-				break;
-			
-			default:
-// TODO:
-		}
-
-		return false;
-	}
-
-	protected static function clear_cache_timber_database() {
-		global $wpdb;
-		$query = $wpdb->prepare("DELETE FROM $wpdb->options WHERE option_name LIKE '%s'", '_transient_timberloader_%');
-		return $wpdb->query($query);
-	}
-
-	protected static function clear_cache_timber_object() {
-		global $wp_object_cache;
-		if ( isset($wp_object_cache->cache[self::CACHEGROUP]) ) {
-			$items = $wp_object_cache->cache[self::CACHEGROUP];
-			foreach ( $items as $key => $value ) {
-				if ( is_multisite() ) {
-					$key = preg_replace('/^(.*?):/', '', $key);
-				}
-				wp_cache_delete($key, self::CACHEGROUP);
-			}
-			return true;
-		}
 	}
 
 	public function clear_cache_twig() {
@@ -165,13 +122,6 @@ class Loader
 	 * @return \Asm89\Twig\CacheExtension\Extension
 	 */
 	public static function createCacheExtension() {
-
-		$key_generator   = new \Timber\Cache\KeyGenerator();
-		$cache_provider  = new \Timber\Cache\WPObjectCacheAdapter(new self());
-		$cache_strategy  = new \Asm89\Twig\CacheExtension\CacheStrategy\GenerationalCacheStrategy($cache_provider, $key_generator);
-		$cache_extension = new \Asm89\Twig\CacheExtension\Extension($cache_strategy);
-
-		return $cache_extension;
 	}
 
 	/**
@@ -181,33 +131,6 @@ class Loader
 	 * @return bool
 	 */
 	public function get_cache( $key, $group = self::CACHEGROUP, $cache_mode = self::CACHE_USE_DEFAULT ) {
-		$value = false;
-
-		$trans_key = substr($group.'_'.$key, 0, self::TRANS_KEY_LEN);
-		
-		$cache_mode = $this->_get_cache_mode($cache_mode);
-		switch ($cache_mode) {
-				
-			case self::CACHE_TRANSIENT:
-				$value = get_transient($trans_key);
-				break;
-				
-			case self::CACHE_SITE_TRANSIENT:
-				$value = get_site_transient($trans_key);
-				break;
-
-			case self::CACHE_OBJECT:
-				$object_cache = isset($GLOBALS['wp_object_cache']) && is_object($GLOBALS['wp_object_cache']);
-				if ($object_cache) {
-					$value = wp_cache_get($key, $group);
-				}
-				break;
-				
-			default:
-// TODO:
-		}
-
-		return $value;
 	}
 
 	/**
@@ -219,52 +142,6 @@ class Loader
 	 * @return string|boolean
 	 */
 	public function set_cache( $key, $value, $group = self::CACHEGROUP, $expires = 0, $cache_mode = self::CACHE_USE_DEFAULT ) {
-		if ( (int) $expires < 1 ) {
-			$expires = 0;
-		}
-
-		$trans_key = substr($group.'_'.$key, 0, self::TRANS_KEY_LEN);
-
-		$cache_mode = self::_get_cache_mode($cache_mode);
-		switch ($cache_mode) {
-		
-			case self::CACHE_TRANSIENT:
-				set_transient($trans_key, $value, $expires);
-				break;
-		
-			case self::CACHE_SITE_TRANSIENT:
-				set_site_transient($trans_key, $value, $expires);
-				break;
-		
-			case self::CACHE_OBJECT:
-				$object_cache = isset($GLOBALS['wp_object_cache']) && is_object($GLOBALS['wp_object_cache']);
-				if ($object_cache) {
-					wp_cache_set($key, $value, $group, $expires);
-				}
-				break;
-
-			default:
-// TODO: 
-		}
-
-		return $value;
-	}
-
-	/**
-	 * @param string $cache_mode
-	 * @return string
-	 */
-	private function _get_cache_mode( $cache_mode ) {
-		if ( empty($cache_mode) || self::CACHE_USE_DEFAULT === $cache_mode ) {
-			$cache_mode = $this->cache_mode;
-		}
-
-		// Fallback if self::$cache_mode did not get a valid value
-		if ( !in_array($cache_mode, self::$cache_modes) ) {
-			$cache_mode = self::CACHE_OBJECT;
-		}
-
-		return $cache_mode;
 	}
 
 }

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -7,15 +7,15 @@ use Timber\Cache\Cleaner;
 class Loader 
 	extends Cache
 {
-	const CACHEGROUP = 'timberloader';
+	const CACHEGROUP = Cache::CACHEGROUP;
 
-	const TRANS_KEY_LEN = 50;
+	const TRANS_KEY_LEN = Cache::TRANS_KEY_LEN;
 
-	const CACHE_NONE = 'none';
-	const CACHE_OBJECT = 'cache';
-	const CACHE_TRANSIENT = 'transient';
-	const CACHE_SITE_TRANSIENT = 'site-transient';
-	const CACHE_USE_DEFAULT = 'default';
+	const CACHE_NONE = Cache::CACHE_NONE;
+	const CACHE_OBJECT = Cache::CACHE_OBJECT;
+	const CACHE_TRANSIENT = Cache::CACHE_TRANSIENT;
+	const CACHE_SITE_TRANSIENT = Cache::CACHE_SITE_TRANSIENT;
+	const CACHE_USE_DEFAULT = Cache::CACHE_USE_DEFAULT;
 
 	public static $cache_modes = array(
 		self::CACHE_NONE,

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -487,7 +487,7 @@ class Timber {
 				$key = md5($name.json_encode($context));
 
 				// Load cached output
-				$output = $cache->get_cache($key, LOADER::CACHEGROUP, $cache_mode);
+				$output = $cache->fetch($key, LOADER::CACHEGROUP, $cache_mode);
 			}
 
 			// If no output at this point, generate some...
@@ -520,7 +520,7 @@ class Timber {
 				// Erase cache
 				$cache->delete_cache();
 				// Store output
-				$cache->set_cache($key, $output, Loader::CACHEGROUP, $expires, $cache_mode);
+				$cache->save($key, $output, Loader::CACHEGROUP, $expires, $cache_mode);
 			}
 //
 // Content from moved Loader::render() ends here.

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -348,7 +348,7 @@ class Timber {
 			$twigEnvironment->addExtension(new \Twig_Extension_Debug());
 		}
 
-		$twigEnvironment->addExtension(Loader::createCacheExtension());
+		$twigEnvironment->addExtension(Cache::createCacheExtension());
 
 		do_action('timber/twig', $twigEnvironment);
 		/**
@@ -423,7 +423,7 @@ class Timber {
 	 * @param bool         $via_render Optional. Whether to apply optional render or compile filters. Default false.
 	 * @return bool|string The returned output.
 	 */
-	public static function compile( $names, $context = array(), $expires = false, $cache_mode = Loader::CACHE_USE_DEFAULT, $via_render = false ) {
+	public static function compile( $names, $context = array(), $expires = false, $cache_mode = Cache::CACHE_USE_DEFAULT, $via_render = false ) {
 		if ( !defined('TIMBER_LOADED') ) {
 			new self();
 		}
@@ -487,7 +487,7 @@ class Timber {
 				$key = md5($name.json_encode($context));
 
 				// Load cached output
-				$output = $cache->fetch($key, LOADER::CACHEGROUP, $cache_mode);
+				$output = $cache->fetch($key, Cache::CACHEGROUP, $cache_mode);
 			}
 
 			// If no output at this point, generate some...
@@ -520,7 +520,7 @@ class Timber {
 				// Erase cache
 				$cache->delete_cache();
 				// Store output
-				$cache->save($key, $output, Loader::CACHEGROUP, $expires, $cache_mode);
+				$cache->save($key, $output, Cache::CACHEGROUP, $expires, $cache_mode);
 			}
 //
 // Content from moved Loader::render() ends here.
@@ -574,7 +574,7 @@ class Timber {
 	 * @param string       $cache_mode Optional. Any of the cache mode constants defined in TimberLoader.
 	 * @return bool|string The returned output.
 	 */
-	public static function fetch( $names, $context = array(), $expires = false, $cache_mode = Loader::CACHE_USE_DEFAULT ) {
+	public static function fetch( $names, $context = array(), $expires = false, $cache_mode = Cache::CACHE_USE_DEFAULT ) {
 		$output = self::compile($names, $context, $expires, $cache_mode, true);
 		$output = apply_filters('timber_compile_result', $output);
 		return $output;
@@ -601,7 +601,7 @@ class Timber {
 	 * @param string       $cache_mode Optional. Any of the cache mode constants defined in TimberLoader.
 	 * @return bool|string The echoed output.
 	 */
-	public static function render( $names, $context = array(), $expires = false, $cache_mode = Loader::CACHE_USE_DEFAULT ) {
+	public static function render( $names, $context = array(), $expires = false, $cache_mode = Cache::CACHE_USE_DEFAULT ) {
 		$output = self::fetch($names, $context, $expires, $cache_mode);
 		echo $output;
 		return $output;


### PR DESCRIPTION
- Change variable names to use same terminology as Twig.

- Move code from previous Loader::render() into Timber::compile().

- Introduce new Cache class, based on code from the Loader class, which is no primarily a dummy class with deprecated methods. Constants also ‘forward’ to the Cache class.

- Change naming of caching methods to be identical with Asm89