### PR TITLE
Make loader class a shallow lecagy class.

### DIFF
--- a/lib/Cache.php
+++ b/lib/Cache.php
@@ -34,22 +34,24 @@ class Cache
 		$this->cache_mode = apply_filters('timber/cache/mode', $this->cache_mode);
 	}
 
-	public function delete_cache() {
+	public function deleteCache()
+	{
 		Cleaner::delete_transients();
 	}
 
-	public function clear_cache_timber( $cache_mode = self::CACHE_USE_DEFAULT ) {
-		$cache_mode = $this->_get_cache_mode($cache_mode);
+	public function clearCacheTimber( $cache_mode = self::CACHE_USE_DEFAULT )
+	{
+		$cache_mode = $this->filterCacheMode($cache_mode);
 		switch ($cache_mode) {
 				
 			case self::CACHE_TRANSIENT:
 			case self::CACHE_SITE_TRANSIENT:
-				return self::clear_cache_timber_database();
+				return self::clearCacheTimberDatabase();
 			
 			case self::CACHE_OBJECT:
 				$object_cache = isset($GLOBALS['wp_object_cache']) && is_object($GLOBALS['wp_object_cache']);
 				if ($object_cache) {
-					return self::clear_cache_timber_object();
+					return self::clearCacheTimberObject();
 				}
 				break;
 			
@@ -60,13 +62,15 @@ class Cache
 		return false;
 	}
 
-	protected static function clear_cache_timber_database() {
+	protected static function clearCacheTimberDatabase()
+	{
 		global $wpdb;
 		$query = $wpdb->prepare("DELETE FROM $wpdb->options WHERE option_name LIKE '%s'", '_transient_timberloader_%');
 		return $wpdb->query($query);
 	}
 
-	protected static function clear_cache_timber_object() {
+	protected static function clearCacheTimberObject()
+	{
 		global $wp_object_cache;
 		if ( isset($wp_object_cache->cache[self::CACHEGROUP]) ) {
 			$items = $wp_object_cache->cache[self::CACHEGROUP];
@@ -104,7 +108,7 @@ class Cache
 
 		$trans_key = substr($group.'_'.$key, 0, self::TRANS_KEY_LEN);
 		
-		$cache_mode = $this->_get_cache_mode($cache_mode);
+		$cache_mode = $this->filterCacheMode($cache_mode);
 		switch ($cache_mode) {
 				
 			case self::CACHE_TRANSIENT:
@@ -144,7 +148,7 @@ class Cache
 
 		$trans_key = substr($group.'_'.$key, 0, self::TRANS_KEY_LEN);
 
-		$cache_mode = self::_get_cache_mode($cache_mode);
+		$cache_mode = self::filterCacheMode($cache_mode);
 		switch ($cache_mode) {
 		
 			case self::CACHE_TRANSIENT:
@@ -173,7 +177,8 @@ class Cache
 	 * @param string $cache_mode
 	 * @return string
 	 */
-	private function _get_cache_mode( $cache_mode ) {
+	private function filterCacheMode( $cache_mode )
+	{
 		if ( empty($cache_mode) || self::CACHE_USE_DEFAULT === $cache_mode ) {
 			$cache_mode = $this->cache_mode;
 		}

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -23,7 +23,6 @@ final class Loader
 		self::CACHE_SITE_TRANSIENT
 	);
 
-	private $twigEnvironment;
 	private $cacheInstance;
 	
 	/**
@@ -32,9 +31,6 @@ final class Loader
 	 */
 	public function __construct(\Twig_Environment $twig = null)
 	{	
-		if ($twig !== null) {
-			$this->twigEnvironment = $twig;
-		}
 		
 		$this->cacheInstance = new Cache();
 	}
@@ -73,7 +69,7 @@ final class Loader
 	 * @todo remove
 	 */
 	public function get_twig() {
-		return $this->twigEnvironment;
+		return Timber::getTwigEnvironment();
 	}
 
 	public function clear_cache_timber( $cache_mode = self::CACHE_USE_DEFAULT ) {
@@ -84,9 +80,9 @@ final class Loader
 		if ( method_exists($this, 'clearCacheFiles') ) {
 			$this->clearCacheFiles();
 		}
-		$cache = $this->twigEnvironment->getCache();
+		$cache = Timber::getTwigEnvironment()->getCache();
 		if ( $cache ) {
-			self::rrmdir($this->twigEnvironment->getCache());
+			self::rrmdir(Timber::getTwigEnvironment()->getCache());
 			return true;
 		}
 		return false;

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -78,7 +78,7 @@ final class Loader
 	}
 
 	public function clear_cache_timber( $cache_mode = self::CACHE_USE_DEFAULT ) {
-		return $this->cacheInstance->clear_cache_timber( $cache_mode);
+		return $this->cacheInstance->clearCacheTimber( $cache_mode);
 	}
 
 	public function clear_cache_twig() {

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -26,12 +26,10 @@ final class Loader
 	private $cacheInstance;
 	
 	/**
-	 *
-	 * @param \Twig_Environment $twig
+	 * @param bool|string   $caller the calling directory or false
 	 */
-	public function __construct(\Twig_Environment $twig = null)
-	{	
-		
+	public function __construct( $caller = false )
+	{
 		$this->cacheInstance = new Cache();
 	}
 

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -21,6 +21,7 @@ final class Loader
 		self::CACHE_SITE_TRANSIENT
 	);
 
+	private $twigEnvironment;
 	private $cacheInstance;
 	
 	/**
@@ -28,6 +29,8 @@ final class Loader
 	 */
 	public function __construct( $caller = false )
 	{
+		$this->twigEnvironment = Timber::getTwigEnvironment();
+		
 		$this->cacheInstance = new Cache();
 	}
 
@@ -61,11 +64,11 @@ final class Loader
 	public function get_loader() {
 // TODO: Remove.
 		// This returns a proxy filesystem loader to preserve backward compatibility, by letting users add (but not remove internal) paths.
-		if ($this->twig->getLoader() instanceof ChainLoader) {
-			return $this->twig->getLoader()->getTemporaryLoader();
+		if ($this->twigEnvironment->getLoader() instanceof ChainLoader) {
+			return $this->twigEnvironment->getLoader()->getTemporaryLoader();
 		}
 		// Just return loader...
-		return $this->twig->getLoader();
+		return $this->twigEnvironment->getLoader();
 	}
 
 
@@ -75,7 +78,7 @@ final class Loader
 	 * @todo remove
 	 */
 	public function get_twig() {
-		return Timber::getTwigEnvironment();
+		return $this->twigEnvironment;
 	}
 
 	public function clear_cache_timber( $cache_mode = self::CACHE_USE_DEFAULT ) {
@@ -86,9 +89,9 @@ final class Loader
 		if ( method_exists($this, 'clearCacheFiles') ) {
 			$this->clearCacheFiles();
 		}
-		$cache = Timber::getTwigEnvironment()->getCache();
+		$cache = $this->twigEnvironment->getCache();
 		if ( $cache ) {
-			self::rrmdir(Timber::getTwigEnvironment()->getCache());
+			self::rrmdir($this->twigEnvironment->getCache());
 			return true;
 		}
 		return false;

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -34,16 +34,25 @@ final class Loader
 	}
 
 	/**
-	 * @param string $name
-	 * @return bool
-	 * @deprecated 1.3.5 No longer used internally
-	 * @todo remove in 2.x
-	 * @codeCoverageIgnore
+	 * @param string        	$file
+	 * @param array         	$data
+	 * @param array|boolean    	$expires (array for options, false for none, integer for # of seconds)
+	 * @param string        	$cache_mode
+	 * @return bool|string
 	 */
-	protected function template_exists( $name ) {
-		return $this->twig->getLoader()->exists($name);
+	public function render( $file, $data = null, $expires = false, $cache_mode = self::CACHE_USE_DEFAULT ) {
+// TODO: This results in a circularity...
 	}
 
+	/**
+	 * Get first existing template.
+	 *
+	 * @param array|string $templates  Name(s) of the Twig template(s) to choose from.
+	 * @return string|bool             Name of chosen template, otherwise false.
+	 */
+	public function choose_template( $templates ) {
+		$this->cacheInstance->clearCacheTimber();
+	}
 
 	/**
 	 * @return \Twig_LoaderInterface
@@ -107,14 +116,7 @@ final class Loader
 		rmdir($dirPath);
 	}
 
-	/**
-	 * @return \Asm89\Twig\CacheExtension\Extension
-	 */
-	public static function createCacheExtension() {
-		return Cache::createCacheExtension();
-	}
-
-	/**
+	/*
 	 * @param string $key
 	 * @param string $group
 	 * @param string $cache_mode

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -34,6 +34,10 @@ final class Loader
 		if (! $this->twigEnvironment->getLoader() instanceof CallerCompatibleLoaderInterface) {
 			throw new \Exception('The Twig Environment loader must implement CallerCompatibleLoaderInterface for the to work.');
 		}
+		if ($caller !== false) {
+			$this->twigEnvironment->getLoader()->setCaller($caller);
+		}
+		
 		$this->cacheInstance = new Cache();
 	}
 

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -4,7 +4,7 @@ namespace Timber;
 
 use Timber\Cache\Cleaner;
 
-class Loader
+final class Loader
 {
 	const CACHEGROUP = Cache::CACHEGROUP;
 

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -2,8 +2,6 @@
 
 namespace Timber;
 
-use Timber\Cache\Cleaner;
-
 final class Loader
 {
 	const CACHEGROUP = Cache::CACHEGROUP;

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -31,6 +31,9 @@ final class Loader
 	{
 		$this->twigEnvironment = Timber::getTwigEnvironment();
 		
+		if (! $this->twigEnvironment->getLoader() instanceof CallerCompatibleLoaderInterface) {
+			throw new \Exception('The Twig Environment loader must implement CallerCompatibleLoaderInterface for the to work.');
+		}
 		$this->cacheInstance = new Cache();
 	}
 

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -39,7 +39,8 @@ final class Loader
 	 * @return bool|string
 	 */
 	public function render( $file, $data = null, $expires = false, $cache_mode = self::CACHE_USE_DEFAULT ) {
-// TODO: This results in a circularity...
+		// NB: This will trigger a few more filteres that originally.
+		return Timber::compile($file, $data, $expires, $cache_mode);
 	}
 
 	/**

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -472,7 +472,7 @@ class Timber {
 			$output = false;
 
 // TODO: This is a temoprary hack!
-			$cache = new Cache($twigEnvironment);
+			$cache = new Cache();
 
 			// Only load cached data when $expires is not false
 			// NB: Caching is disabled, when $expires is false!

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -518,7 +518,7 @@ class Timber {
 			// Update cache, when 3) $key has been ser, 2) $expires != false, and 1) $output has ben changed from the initial false
 			if ( false !== $output && false !== $expires && null !== $key ) {
 				// Erase cache
-				$cache->delete_cache();
+				$cache->deleteCache();
 				// Store output
 				$cache->save($key, $output, Cache::CACHEGROUP, $expires, $cache_mode);
 			}


### PR DESCRIPTION
Try to imitate original behavior of Loader class, which is made final to avoid problematic inheritance.

NB. clear_cache_twig() and rrmdir() has not been moved yet, since they relate to Twig, and might therefore not belong together with the Timber related cache, which has been moved to the new Cache class...